### PR TITLE
Fixing build by removing unrecognized option of ndk. Please review.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -83,7 +83,7 @@ git clone "${FFMPEG_BARE_PATH}" "${FFMPEG_DIR}"
 
 "${NDK_PATH}"/build/tools/make_standalone_toolchain.py \
             --arch "${ARCH}" --api ${ANDROID_API} \
-            --stl libc++ --unified-headers \
+            --stl libc++ \
             --install-dir "${CROSS_DIR}" --force
 
 #here we source a file that sets CONFIG_LIBAV string to the config we want


### PR DESCRIPTION
This is the issue I had trying to build from scratch. 
It seems that the '--unified-headers' is not supported by the 'make_standalone_toolchain.py' script.
Having made that fix, I'm able to go forward and generate the app.